### PR TITLE
ページの修正

### DIFF
--- a/pr1_2.html
+++ b/pr1_2.html
@@ -41,33 +41,33 @@
 </head>
 <body>
 <h1>実験用HTMLページ</h1>
-<h2>カラーボック</h2>
-<div id="box１">
+<h2>カラーボックス</h2>
+<div id="box1">
     <div id="colorbox1" style="background-color: red;
                                border: black 2px solid;
-                               pading: 50px 50px 50px 50px;"
+                               padding: 50px 50px 50px 50px;"
     ></div>
 <br>
     <div id="colorbox2" style="background-color: yellow;
                                border: black 2px solio;
-                               padding: 50px 5px 50px 50px;"
+                               padding: 50px 50px 50px 50px;"
     ></div>
 <br>
-    <div id="colorbox3" style="background-color: white;
+    <div id="colorbox3" style="background-color: blue;
                                border: brack 2px solid;
                                padding: 50px 50px 50px 50px;"
     ></div>
 <br>
     <div id="colorbox4" style="border: black 2px solid;
-                               pading: 50px 50px 50px 50px;
-                               background-color: gren;"
+                               padding: 50px 50px 50px 50px;
+                               background-color: green;"
     ></div>
 <br>
 </div>
-<span>要素ならべ</span>
-<div class="cyan_elements"></div>
-<dir class="yellow_element"></dir>
-<hr class="magenta_element"></hr>
+<h2>要素ならべ</h2>
+<div class="cyan_element"></div>
+<div class="yellow_element"></div>
+<div class="magenta_element"></div>
 <div class="black_element"></div>
 </body>
 </html>


### PR DESCRIPTION
「カラーボックス」見出しのスペルミス修正
赤黄青緑ボックスのそれぞれのスペルミス修正
box1の1が全角になっていた
「要素並べ」をh2にした
cyan_elementsになってたのでs除いた